### PR TITLE
Added a lookup in case the TicketID is empty, but the TicketNumber is available.

### DIFF
--- a/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
+++ b/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
@@ -57,24 +57,24 @@ sub Run {
     if ( $Param{TemplateFile} eq 'AgentTicketZoom' ) {
 
         # get ticket id
-        my $TicketID = $ParamObject->GetParam( Param => 'TicketID' );
-        my $TicketNr = $ParamObject->GetParam( Param => 'TicketNumber' );
+        my $TicketID     = $ParamObject->GetParam( Param => 'TicketID' );
+        my $TicketNumber = $ParamObject->GetParam( Param => 'TicketNumber' );
 
         # get ticket id in case necessary
-        if ( ! $TicketID ) {
+        if ( !$TicketID ) {
             $TicketID = $TicketObject->TicketIDLookup(
-                TicketNumber => $TicketNr,
+                TicketNumber => $TicketNumber,
             );
         }
 
-        if ( ! $TicketID ) {
+        if ( !$TicketID ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
                 Message  => "Need TicketID or TicketNumber!",
             );
             return;
         }
-
+        
 
         # Get ticket attributes.
         my %Ticket = $TicketObject->TicketGet(

--- a/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
+++ b/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
@@ -74,7 +74,6 @@ sub Run {
             );
             return;
         }
-        
 
         # Get ticket attributes.
         my %Ticket = $TicketObject->TicketGet(

--- a/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
+++ b/Kernel/Output/HTML/FilterElementPost/ITSMIncidentProblemManagement.pm
@@ -58,6 +58,23 @@ sub Run {
 
         # get ticket id
         my $TicketID = $ParamObject->GetParam( Param => 'TicketID' );
+        my $TicketNr = $ParamObject->GetParam( Param => 'TicketNumber' );
+
+        # get ticket id in case necessary
+        if ( ! $TicketID ) {
+            $TicketID = $TicketObject->TicketIDLookup(
+                TicketNumber => $TicketNr,
+            );
+        }
+
+        if ( ! $TicketID ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need TicketID or TicketNumber!",
+            );
+            return;
+        }
+
 
         # Get ticket attributes.
         my %Ticket = $TicketObject->TicketGet(


### PR DESCRIPTION
… there.

The missing lookup created a lot of errors in case your URL is like https://FQDN/otrs/index.pl?Action=AgentTicketZoom;TicketNumber=95123456